### PR TITLE
Install JDK 11, set path and attempt build

### DIFF
--- a/GoogleAIStudioClient/gradle.properties
+++ b/GoogleAIStudioClient/gradle.properties
@@ -2,3 +2,5 @@
 RELEASE_STORE_PASSWORD=123456
 RELEASE_KEY_PASSWORD=123456
 RELEASE_KEY_ALIAS=fakekey
+
+org.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64


### PR DESCRIPTION
## Summary
- add `org.gradle.java.home` to point to the installed JDK 11

## Testing
- `./gradlew clean` *(fails: Android Gradle plugin requires Java 17)*
- `./gradlew assembleDebug` *(fails: Android Gradle plugin requires Java 17)*


------
https://chatgpt.com/codex/tasks/task_e_684f7a38c3a4832b8b99f776f68fa103